### PR TITLE
Remove restrictions on pending declarations in INI parsing

### DIFF
--- a/lib/ansible/inventory/ini.py
+++ b/lib/ansible/inventory/ini.py
@@ -170,17 +170,6 @@ class InventoryParser(object):
             else:
                 self._raise_error("Entered unhandled state: %s" % (state))
 
-        # Any entries in pending_declarations not removed by a group declaration
-        # above mean that there was an unresolved forward reference. We report
-        # only the first such error here.
-
-        for g in pending_declarations:
-            decl = pending_declarations[g]
-            if decl['state'] == 'vars':
-                raise AnsibleError("%s:%d: Section [%s:vars] not valid for undefined group: %s" % (self.filename, decl['line'], decl['name'], decl['name']))
-            elif decl['state'] == 'children':
-                raise AnsibleError("%s:%d: Section [%s:children] includes undefined group: %s" % (self.filename, decl['line'], decl['parent'], decl['name']))
-
         # Finally, add all top-level groups as children of 'all'.
         # We exclude ungrouped here because it was already added as a child of
         # 'all' at the time it was created.


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```

```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->

```

```

Removes the restrictures previously placed on INI files that they could
not reference groups for vars and child groups not defined in the INI file
itself.

Fixes #16116
